### PR TITLE
separate to two contexts to avoid multithreading bugs [SKY-5686]

### DIFF
--- a/Classes/CoreDataManager.h
+++ b/Classes/CoreDataManager.h
@@ -25,6 +25,8 @@
 
 @interface CoreDataManager : NSObject
 
+@property (readonly, nonatomic) NSManagedObjectContext *privateManagedObjectContext;
+@property (readonly, nonatomic) NSManagedObjectContext *mainManagedObjectContext;
 @property (readonly, nonatomic) NSManagedObjectContext *managedObjectContext;
 @property (readonly, nonatomic) NSManagedObjectModel *managedObjectModel;
 @property (readonly, strong, nonatomic) NSPersistentStoreCoordinator *persistentStoreCoordinator;


### PR DESCRIPTION
to easily encapsulate the switching of contexts and avoid multi-threading bugs.

read: https://cocoacasts.com/core-data-and-concurrency/

for more info on concurrency in core data